### PR TITLE
fix: correct PropTypes + fixed error in onMouseDown() event.

### DIFF
--- a/packages/react-network-diagrams/lib/components/ConcatenatedCircuit.js
+++ b/packages/react-network-diagrams/lib/components/ConcatenatedCircuit.js
@@ -384,7 +384,7 @@ ConcatenatedCircuit.propTypes = {
      * when clicked, navigates to that element. Used mainly when we want
      * to show a parent / child relationship between two circuits.
      */
-    parentId: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.Number]),
+    parentId: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number]),
 
     /**
      * Boolean value that determines if the element uses the onSelectionChange

--- a/packages/react-network-diagrams/lib/components/Node.js
+++ b/packages/react-network-diagrams/lib/components/Node.js
@@ -290,7 +290,7 @@ var Node = exports.Node = function (_React$Component) {
                         },
                         onMouseOver: this.handleMouseOver,
                         onMouseDown: function onMouseDown(e) {
-                            return _this2.handleMouseDown();
+                            return _this2.handleMouseDown(e);
                         },
                         onMouseMove: this.handleMouseMove,
                         onMouseUp: this.handleMouseUp

--- a/packages/react-network-diagrams/lib/components/ParallelCircuit.js
+++ b/packages/react-network-diagrams/lib/components/ParallelCircuit.js
@@ -344,7 +344,7 @@ ParallelCircuit.propTypes = {
      * when clicked, navigates to that element. Used mainly when we want
      * to show a parent / child relationship between two circuits.
      */
-    parentId: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.Number]),
+    parentId: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number]),
 
     /**
      * Boolean value that determines if the element uses the onSelectionChange

--- a/packages/react-network-diagrams/src/components/ConcatenatedCircuit.js
+++ b/packages/react-network-diagrams/src/components/ConcatenatedCircuit.js
@@ -356,7 +356,7 @@ ConcatenatedCircuit.propTypes = {
      * when clicked, navigates to that element. Used mainly when we want
      * to show a parent / child relationship between two circuits.
      */
-    parentId: PropTypes.oneOfType([PropTypes.string, PropTypes.Number]),
+    parentId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
      * Boolean value that determines if the element uses the onSelectionChange

--- a/packages/react-network-diagrams/src/components/Node.js
+++ b/packages/react-network-diagrams/src/components/Node.js
@@ -278,7 +278,7 @@ export class Node extends React.Component {
                 <g
                     onClick={e => this.handMouseClick(e)}
                     onMouseOver={this.handleMouseOver}
-                    onMouseDown={e => this.handleMouseDown()}
+                    onMouseDown={e => this.handleMouseDown(e)}
                     onMouseMove={this.handleMouseMove}
                     onMouseUp={this.handleMouseUp}
                 >

--- a/packages/react-network-diagrams/src/components/ParallelCircuit.js
+++ b/packages/react-network-diagrams/src/components/ParallelCircuit.js
@@ -314,7 +314,7 @@ ParallelCircuit.propTypes = {
      * when clicked, navigates to that element. Used mainly when we want
      * to show a parent / child relationship between two circuits.
      */
-    parentId: PropTypes.oneOfType([PropTypes.string, PropTypes.Number]),
+    parentId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
      * Boolean value that determines if the element uses the onSelectionChange


### PR DESCRIPTION
Renamed two instances of `PropTypes.Number` to `PropTypes.number`. Solves #41 
Node component now supplies the event to `handleMouseDown`. Solves #47 
